### PR TITLE
fix: rust optimization flag enabled

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -35,7 +35,7 @@ java bench
 
 ### **Rust**
 ```sh
-rustc bench.rs
+rustc -C opt-level=3 bench.rs
 ./bench.exe
 ```
 


### PR DESCRIPTION
Rust compiler optimization isn't enabled in the current iteration. To have a fair benchmark across all compiled languages I've added this optimization flag